### PR TITLE
Remove "Auth Service" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # op-be-user
-The User and Auth Services for the Backend Layer of OctopOSPrime - Computed Microservices
+The User Service for the Backend Layer of OctopOSPrime - Computed Microservices
 
 [![Build - Test](https://github.com/octoposprime/op-be-user/actions/workflows/ci.yml/badge.svg)](https://github.com/octoposprime/op-be-user/actions/workflows/ci.yml)
 [![Docker Image Publish](https://github.com/octoposprime/op-be-user/actions/workflows/cd.yml/badge.svg)](https://github.com/octoposprime/op-be-user/actions/workflows/cd.yml)


### PR DESCRIPTION
 Closes #55 We removed The "Auth Service" phrase.